### PR TITLE
fixes resize issue based on yval

### DIFF
--- a/client/src/components/Clock/BarCard/Card.jsx
+++ b/client/src/components/Clock/BarCard/Card.jsx
@@ -7,7 +7,7 @@ function Card({ name, rating, xval, yval }) {
         zIndex: `2`,
         border: `1px solid green`,
         width: `20%`,
-        height: `auto%`,
+        height: `20%`,
         textAlign: `center`,
         transform: `translateX(${xval}px) translateY(${yval}px)`,
       }}

--- a/client/src/components/Clock/BarCard/DataDisplay.jsx
+++ b/client/src/components/Clock/BarCard/DataDisplay.jsx
@@ -9,7 +9,8 @@ const Placeholder = () => {
   const [coordinates, setCoordinates] = useState();
   const [coordinatesAndData, setCoordinatesAndData] = useState([]);
   const [loading, setLoading] = useState(true);
-  const { width } = getWindowDimensions();
+  const { width, height } = getWindowDimensions();
+  
 
   // Define thetas as an array of 12 angles in radians
   let thetas = Array.from({ length: 12 }).map((_, index) => {
@@ -20,6 +21,7 @@ const Placeholder = () => {
   for (let i = 0; i < 3; i++) {
     thetas.unshift(thetas.pop());
   }
+
 
   // this useEffect sets the coordinates of the 12 points on the circle in our state to be available once we get bar data
   useEffect(() => {
@@ -44,10 +46,11 @@ const Placeholder = () => {
       setCoordinates(newCoordinates);
     };
 
+
     updateCoordinates();
 
     // waits for the width of the window to change using the useWindowDimensions hook in utils folder
-  }, [width]);
+  }, [width, height]);
 
   // this useEffect combines our coordinate data for circle placement with our bar data from the yelp API (currently hardcoded test data)
   // Remember to change the trigger to the useEffect to be on the successful return of the API call


### PR DESCRIPTION
the issue with resizing wasn't due to the useEffect - it was because the height of each card was set to auto but I was subtracting halfCardWidth from the y (line 41 of DataDisplay) which made it look like the cards weren't staying in the same spot. 

to fix it, i made the height the same as the width (20%) in Card.jsx...if we want to change the height or width we just have to create a new variable for it in DataDisplay that finds half of the dimension we change.